### PR TITLE
fix(mobile): Site title collapses when menu too small

### DIFF
--- a/modules.less
+++ b/modules.less
@@ -1,1 +1,2 @@
 @import "modules/alerts";
+@import "modules/header";

--- a/modules/header.less
+++ b/modules/header.less
@@ -1,0 +1,18 @@
+@media (max-width: 600px) {
+	#header {
+		.header-inner {
+			display: flex;
+
+			.logo {
+				flex: 1;
+
+				a.title {
+					max-width: 100%;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
fixes pichalite/nodebb-theme-material#18

Collapses title with ellipsis when too long for mobile screens. Responsive to any size.
![home nodebb 2016-01-12 20-50-30](https://cloud.githubusercontent.com/assets/1145989/12284632/8025bb80-b96e-11e5-9ab2-65a44ef195b9.png)
