### PR TITLE
Fix missing title in reconnect-alert

### DIFF
--- a/templates/footer.tpl
+++ b/templates/footer.tpl
@@ -15,7 +15,7 @@
 	<div component="toaster/tray" class="alert-window">
 		<div id="reconnect-alert" class="alert alert-dismissable alert-warning clearfix hide" component="toaster/toast">
 			<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-			<p>[[global:reconnecting-message, {title}]]</p>
+			<p>[[global:reconnecting-message, {config.siteTitle}]]</p>
 		</div>
 	</div>
 


### PR DESCRIPTION
This fixes the reconnect-alert to always show the site-title instead of the title, that isn't always available.